### PR TITLE
add the ability to listen for multiple events via the `$event` property.

### DIFF
--- a/src/Cached.php
+++ b/src/Cached.php
@@ -4,6 +4,7 @@ namespace Vormkracht10\PermanentCache;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use ReflectionClass;
 
@@ -52,8 +53,9 @@ abstract class Cached
         [$driver, $ident] = self::parseCacheString($this->store
             ?? throw new \Exception('The $store property in ['.static::class.'] must be overridden'),
         );
+
         Cache::driver($driver)->forever($ident,
-            /** @phpstan-ignore-next-line  */
+            /** @phpstan-ignore-next-line */
             $this->run($event),
         );
     }
@@ -111,20 +113,20 @@ abstract class Cached
     /**
      * Get the event (if any) this cacher listens for.
      *
-     * @return class-string<E>|null
+     * @return array<int, class-string<E>>
      */
-    final public static function getListenerEvent(): ?string
+    final public static function getListenerEvent(): array
     {
         $reflection = new ReflectionClass(static::class);
 
-        $concrete = $reflection->getProperty('event')->getDefaultValue();
+        $concrete = Arr::wrap($reflection->getProperty('event')->getDefaultValue());
 
         /** @phpstan-ignore-next-line */
-        return $concrete ?? ($reflection
+        return $concrete ?: Arr::wrap(($reflection
             ->getMethod('run')
             ->getParameters()[0] ?? null)
             ?->getType()
-            ?->getName();
+            ?->getName());
     }
 
     /**

--- a/src/PermanentCache.php
+++ b/src/PermanentCache.php
@@ -23,7 +23,6 @@ class PermanentCache
             $resolved[$cacher] = $events;
 
             Event::listen($events, $cacher);
-
         }
 
         $this->cachers = array_merge($this->cachers, $resolved ?? []);

--- a/src/PermanentCache.php
+++ b/src/PermanentCache.php
@@ -35,4 +35,9 @@ class PermanentCache
     {
         return $this->cachers;
     }
+
+    public function staticCaches(): array
+    {
+        return array_filter($this->cachers);
+    }
 }

--- a/src/PermanentCache.php
+++ b/src/PermanentCache.php
@@ -12,39 +12,23 @@ class PermanentCache
     protected array $cachers = [];
 
     /**
-     * @var array<class-string, array<class-string<Cached>>>
-     */
-    protected array $static = [];
-
-    /**
      * @param  array<int, class-string<Cached>>  $cachers
      * @return $this
      */
     public function caches(array $cachers): self
     {
         foreach ($cachers as $cacher) {
-            $event = $cacher::getListenerEvent();
+            $events = $cacher::getListenerEvent();
 
-            if (is_null($event)) {
-                $static[] = $cacher;
+            $resolved[$cacher] = $events;
 
-                continue;
-            }
+            Event::listen($events, $cacher);
 
-            $resolved[$event][] = $cacher;
-
-            Event::listen($event, $cacher);
         }
 
         $this->cachers = array_merge($this->cachers, $resolved ?? []);
-        $this->static = array_merge($this->static, $static ?? []);
 
         return $this;
-    }
-
-    public function staticCaches(): array
-    {
-        return $this->static;
     }
 
     public function configuredCaches(): array


### PR DESCRIPTION
Deze PR voegt de mogelijkheid toe om voor meerdere events te luisteren door de `$event` property een default waarde van het type array (met class strings van events) te geven.