### PR TITLE
Add markers for Cached Components

### DIFF
--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -8,7 +8,7 @@ return [
         // Which is useful for debugging and testing, but also for updating
         // the cached value inside another cache when using nested caches
         'markers' => [
-            'enabled' => env('PERMANENT_CACHE_MARKERS_ENABLED', true),
+            'enabled' => env('PERMANENT_CACHE_MARKERS_ENABLED', false),
             'hash' => env('PERMANENT_CACHE_MARKERS_HASH', false),
         ],
     ],

--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -2,8 +2,8 @@
 
 return [
     'components' => [
-        // Add markers around the rendered value of Cached Components.
-        // This helps to identify the cached value in the rendered HTML.
+        // Add markers around the rendered value of Cached Components,
+        // this helps to identify the cached value in the rendered HTML.
 
         // Which is useful for debugging and testing, but also for updating
         // the cached value inside another cache when using nested caches

--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -2,8 +2,9 @@
 
 return [
     'components' => [
-        // Add markers around the rendered value of Cached Components
-        // This helps to identify the cached value in the rendered HTML
+        // Add markers around the rendered value of Cached Components.
+        // This helps to identify the cached value in the rendered HTML.
+
         // Which is useful for debugging and testing, but also for updating
         // the cached value inside another cache when using nested caches
         'markers' => [

--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'components' => [
+        'markers' => [
+            'enabled' => env('PERMANENT_CACHE_MARKERS_ENABLED', true),
+            'hash' => env('PERMANENT_CACHE_MARKERS_HASH', false),
+        ],
+    ],
+];

--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -2,6 +2,10 @@
 
 return [
     'components' => [
+        // Add markers around the rendered value of Cached Components
+        // This helps to identify the cached value in the rendered HTML
+        // Which is useful for debugging and testing, but also for updating
+        // the cached value inside another cache when using nested caches
         'markers' => [
             'enabled' => env('PERMANENT_CACHE_MARKERS_ENABLED', true),
             'hash' => env('PERMANENT_CACHE_MARKERS_HASH', false),

--- a/src/CachedComponent.php
+++ b/src/CachedComponent.php
@@ -44,10 +44,10 @@ abstract class CachedComponent extends Component
 
     public function renderOutput($value): HtmlString
     {
-        if (! config('permanent-cache.components.markers.enabled')) {
-            return new HtmlString($value);
+        if (config('permanent-cache.components.markers.enabled')) {
+            $value = $this->getMarker().$value.$this->getMarker();
         }
 
-        return new HtmlString($this->getMarker().$value.$this->getMarker());
+        return new HtmlString($value);
     }
 }

--- a/src/CachedComponent.php
+++ b/src/CachedComponent.php
@@ -19,11 +19,13 @@ abstract class CachedComponent extends Component
             $this->isUpdating ||
             $this->shouldBeUpdating()
         ) {
-            return $this->renderOutput(parent::resolveView());
+            return $this->renderOutput(
+                parent::resolveView()
+            );
         }
 
         if (null !== $cachedValue = $this->get($this->getParameters())) {
-            return new HtmlString($this->renderOutput((string) $cachedValue));
+            return (new HtmlString($this->renderOutput((string) $cachedValue)));
         }
     }
 
@@ -40,12 +42,12 @@ abstract class CachedComponent extends Component
         return '<!--##########'.$marker.'##########-->';
     }
 
-    public function renderOutput($value): string
+    public function renderOutput($value): HtmlString
     {
         if (! config('permanent-cache.components.markers.enabled')) {
-            return $value;
+            return new HtmlString($value);
         }
 
-        return $this->getMarker().$value.$this->getMarker();
+        return new HtmlString($this->getMarker().$value.$this->getMarker());
     }
 }

--- a/src/CachedComponent.php
+++ b/src/CachedComponent.php
@@ -19,11 +19,11 @@ abstract class CachedComponent extends Component
             $this->isUpdating ||
             $this->shouldBeUpdating()
         ) {
-            return $this->setMarkers(parent::resolveView());
+            return $this->renderOutput(parent::resolveView());
         }
 
         if (null !== $cachedValue = $this->get($this->getParameters())) {
-            return new HtmlString($this->setMarkers((string) $cachedValue));
+            return new HtmlString($this->renderOutput((string) $cachedValue));
         }
     }
 
@@ -40,7 +40,7 @@ abstract class CachedComponent extends Component
         return '<!--##########'.$marker.'##########-->';
     }
 
-    public function setMarkers($value): string
+    public function renderOutput($value): string
     {
         if (! config('permanent-cache.components.markers.enabled')) {
             return $value;

--- a/src/CachesValue.php
+++ b/src/CachesValue.php
@@ -74,7 +74,7 @@ trait CachesValue
         PermanentCacheUpdating::dispatch($this);
 
         $value = is_subclass_of(static::class, CachedComponent::class)
-            ? Blade::renderComponent($this)
+            ? (string) Blade::renderComponent($this)
             : $this->run($event);
 
         if (is_null($value)) {
@@ -152,8 +152,11 @@ trait CachesValue
 
         $cache = Cache::driver($driver);
 
-        if ($update && ! $cache->has($cacheKey)) {
-            static::update($parameters ?? [])->onConnection('sync');
+        if (
+            $update ||
+            ! $cache->has($cacheKey)
+        ) {
+            static::update($parameters ?? [])?->onConnection('sync');
         }
 
         return $cache->get($cacheKey, $default);

--- a/src/CachesValue.php
+++ b/src/CachesValue.php
@@ -94,7 +94,7 @@ trait CachesValue
             ->getProperties(\ReflectionProperty::IS_PUBLIC))
             ->filter(fn (\ReflectionProperty $p) => $p->class === static::class)
             ->mapWithKeys(fn (\ReflectionProperty $p) => [$p->name => $p->getValue($this)])
-            ->toArray();
+            ->all();
     }
 
     /**

--- a/src/PermanentCacheServiceProvider.php
+++ b/src/PermanentCacheServiceProvider.php
@@ -10,7 +10,8 @@ class PermanentCacheServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        $package->name('laravel-permanent-cache');
+        $package->name('laravel-permanent-cache')
+            ->hasConfigFile();
     }
 
     public function registeringPackage()


### PR DESCRIPTION
This PR provides marker functionality to Cached Components, useful when implementing permanent cache that gets 'trapped' inside a nested cache.

This way you could implement event listeners that update/replace the permanent cached value inside the 'parent' cache.

It could also be useful when debugging to view the markers in the HTML source.