### PR TITLE
Add Laravel Prompts to command interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
         "laravel/helpers": "^1.7",
+        "laravel/prompts": "^0.1.25",
         "lorisleiva/cron-translator": "^0.4.5",
         "spatie/emoji": "^4.1",
         "spatie/laravel-package-tools": "^1.14.0"


### PR DESCRIPTION
This pull request introduces a new dependency on the `laravel/prompts` package and updates the `UpdatePermanentCachesCommand` class to utilize the new progress bar functionality provided by this package. The most important changes include the addition of the new package and the refactoring of the progress bar implementation.

Dependency update:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R22): Added `laravel/prompts` package version `^0.1.25`.

Refactoring progress bar implementation:

* [`src/Commands/UpdatePermanentCachesCommand.php`](diffhunk://#diff-eaee0b9092b1fa10298d4ac7ec93504fedd68af3b03dbd99eb2404d5eda3bb4fL9-R12): Replaced the usage of `Symfony\Component\Console\Helper\ProgressBar` with the `progress` function from `laravel/prompts`.
* [`src/Commands/UpdatePermanentCachesCommand.php`](diffhunk://#diff-eaee0b9092b1fa10298d4ac7ec93504fedd68af3b03dbd99eb2404d5eda3bb4fL50-L79): Updated the `handle` method to use the new progress bar's `cancelMessage` and `hint` methods instead of `setMessage`.