### PR TITLE
Per-record model caching via HasPermanentCache trait

### DIFF
--- a/config/permanent-cache.php
+++ b/config/permanent-cache.php
@@ -3,6 +3,12 @@
 return [
     'store' => env('PERMANENT_CACHE_STORE', 'file'),
 
+    // Defaults for per-record model caching (Concerns\HasPermanentCache).
+    // These are fall-throughs only — each model can override every value.
+    'models' => [
+        'chunk' => 1000,
+    ],
+
     'components' => [
         // Add markers around the rendered value of Cached Components,
         // this helps to identify the cached value in the rendered HTML.

--- a/src/Commands/UpdatePermanentCacheCommand.php
+++ b/src/Commands/UpdatePermanentCacheCommand.php
@@ -63,12 +63,12 @@ class UpdatePermanentCacheCommand extends Command
             $currentTask = $cache->getName();
             $emoji = ($progressBar->getProgress() % 2 ? Emoji::hourglassNotDone() : Emoji::hourglassDone());
 
-            $progressBar->setMessage('Updating: ' . $currentTask . ' ' . $emoji);
+            $progressBar->setMessage('Updating: '.$currentTask.' '.$emoji);
 
             try {
                 $cache->update($parameters);
             } catch (Exception $exception) {
-                $progressBar->setMessage('Error: ' . $currentTask . ' ' . Emoji::warning());
+                $progressBar->setMessage('Error: '.$currentTask.' '.Emoji::warning());
 
                 sleep(2);
             }
@@ -78,5 +78,18 @@ class UpdatePermanentCacheCommand extends Command
 
         $progressBar->setMessage('Finished!');
         $progressBar->finish();
+
+        $this->newLine();
+
+        $models = collect(PermanentCache::registeredModels())
+            ->filter(fn (string $class) => ! $this->option('filter')
+                || str_contains(strtolower($class), strtolower($this->option('filter'))))
+            ->values();
+
+        if ($models->isNotEmpty()) {
+            $this->call(WarmPermanentCacheCommand::class, [
+                '--filter' => $this->option('filter') ?: null,
+            ]);
+        }
     }
 }

--- a/src/Commands/WarmPermanentCacheCommand.php
+++ b/src/Commands/WarmPermanentCacheCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Backstage\PermanentCache\Laravel\Commands;
+
+use Backstage\PermanentCache\Laravel\Concerns\HasPermanentCache;
+use Backstage\PermanentCache\Laravel\Facades\PermanentCache;
+use Backstage\PermanentCache\Laravel\Jobs\RefreshModelCacheJob;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Emoji\Emoji;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class WarmPermanentCacheCommand extends Command
+{
+    protected $signature = 'permanent-cache:warm
+                            {--filter= : Only warm models whose class name contains this fragment}
+                            {--queue : Force dispatch onto the queue regardless of model setting}
+                            {--sync : Force synchronous warming regardless of model setting}
+                            {--chunk=1000 : Number of records to load per chunk}';
+
+    protected $description = 'Warm per-record permanent caches for all registered models';
+
+    public function handle(): int
+    {
+        $models = collect(PermanentCache::registeredModels())
+            ->filter(fn (string $class) => ! $this->option('filter')
+                || str_contains(strtolower($class), strtolower($this->option('filter'))));
+
+        if ($models->isEmpty()) {
+            $this->info('No registered models match the filter.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($models as $class) {
+            $this->warmModel($class);
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function warmModel(string $class): void
+    {
+        if (! is_subclass_of($class, Model::class) || ! in_array(HasPermanentCache::class, class_uses_recursive($class), true)) {
+            $this->warn("Skipping {$class}: not an Eloquent model using HasPermanentCache.");
+
+            return;
+        }
+
+        $total = $class::permanentCacheableQuery()->toBase()->getCountForPagination();
+
+        ProgressBar::setFormatDefinition('permanent-cache-warm', ' %current%/%max% [%bar%] %message%');
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->setFormat('permanent-cache-warm');
+        $bar->setMessage("Warming {$class}");
+        $bar->start();
+
+        $chunk = (int) ($this->option('chunk') ?: 1000);
+
+        $class::permanentCacheableQuery()->chunkById($chunk, function ($records) use ($bar, $class) {
+            foreach ($records as $record) {
+                try {
+                    $this->refresh($record);
+                    $emoji = ($bar->getProgress() % 2 ? Emoji::hourglassNotDone() : Emoji::hourglassDone());
+                    $bar->setMessage("Warming {$class} {$emoji}");
+                } catch (Exception $e) {
+                    $bar->setMessage("Error: {$class}#{$record->getKey()} ".Emoji::warning());
+                }
+
+                $bar->advance();
+            }
+        });
+
+        $bar->setMessage("Finished {$class}");
+        $bar->finish();
+        $this->newLine();
+    }
+
+    protected function refresh(Model $model): void
+    {
+        if ($this->option('sync')) {
+            $model->writePermanentCache();
+
+            return;
+        }
+
+        if ($this->option('queue')) {
+            RefreshModelCacheJob::dispatch($model);
+
+            return;
+        }
+
+        $model->refreshCache();
+    }
+}

--- a/src/Concerns/HasPermanentCache.php
+++ b/src/Concerns/HasPermanentCache.php
@@ -39,7 +39,7 @@ trait HasPermanentCache
             $entry = $this->getPermanentCacheEntry();
         }
 
-        return $entry?->value ?? $default;
+        return $entry !== null ? ($entry['value'] ?? $default) : $default;
     }
 
     public function refreshCache(): mixed
@@ -71,9 +71,9 @@ trait HasPermanentCache
 
         [$store, $key] = $this->resolvePermanentCacheStore();
 
-        Cache::store($store)->forever($key, (object) [
+        Cache::store($store)->forever($key, [
             'value' => $value,
-            'updated_at' => now(),
+            'updated_at' => now()->toIso8601String(),
         ]);
 
         PermanentCacheUpdated::dispatch($this, $value);
@@ -97,7 +97,10 @@ trait HasPermanentCache
 
     public function cacheUpdatedAt(): ?Carbon
     {
-        return $this->getPermanentCacheEntry()?->updated_at;
+        $entry = $this->getPermanentCacheEntry();
+        $value = $entry['updated_at'] ?? null;
+
+        return $value ? Carbon::parse($value) : null;
     }
 
     public function getPermanentCacheKey(): string
@@ -154,13 +157,16 @@ trait HasPermanentCache
         return [$store, $key];
     }
 
-    protected function getPermanentCacheEntry(): ?object
+    /**
+     * @return array{value: mixed, updated_at: string}|null
+     */
+    protected function getPermanentCacheEntry(): ?array
     {
         [$store, $key] = $this->resolvePermanentCacheStore();
 
         $entry = Cache::store($store)->get($key);
 
-        return is_object($entry) ? $entry : null;
+        return is_array($entry) ? $entry : null;
     }
 
     protected function shouldQueuePermanentCache(): bool

--- a/src/Concerns/HasPermanentCache.php
+++ b/src/Concerns/HasPermanentCache.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Backstage\PermanentCache\Laravel\Concerns;
+
+use Backstage\PermanentCache\Laravel\Events\PermanentCacheUpdated;
+use Backstage\PermanentCache\Laravel\Events\PermanentCacheUpdating;
+use Backstage\PermanentCache\Laravel\Jobs\RefreshModelCacheJob;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Adds per-record permanent caching to an Eloquent model.
+ *
+ * @mixin Model
+ *
+ * Required:
+ *   public function cachedResult(): mixed { ... }
+ *
+ * Optional:
+ *   protected ?string $permanentCacheStore         // 'driver:identifier' (same shape as Cached::$store)
+ *   protected ?string $permanentCacheExpression    // cron expression for scheduled re-warm
+ *   protected bool    $permanentCacheQueue         // true = dispatch refresh on the queue
+ *   protected ?string $permanentCacheQueueConnection
+ *   protected ?string $permanentCacheQueueName
+ *   public function scopePermanentCacheable($query) // restrict warm/iteration set
+ */
+trait HasPermanentCache
+{
+    public function cached(mixed $default = null): mixed
+    {
+        $entry = $this->getPermanentCacheEntry();
+
+        if ($entry === null) {
+            $this->refreshCache();
+
+            $entry = $this->getPermanentCacheEntry();
+        }
+
+        return $entry?->value ?? $default;
+    }
+
+    public function refreshCache(): mixed
+    {
+        if ($this->shouldQueuePermanentCache()) {
+            RefreshModelCacheJob::dispatch($this)
+                ->onConnection($this->permanentCacheQueueConnection ?? null)
+                ->onQueue($this->permanentCacheQueueName ?? null);
+
+            return null;
+        }
+
+        return $this->writePermanentCache();
+    }
+
+    /**
+     * Compute and store the cached value synchronously. Always sync, regardless of queue settings.
+     * Used by the queued job and the warm command's sync mode.
+     */
+    public function writePermanentCache(): mixed
+    {
+        if (! method_exists($this, 'cachedResult')) {
+            throw new \LogicException(static::class.' uses HasPermanentCache but does not implement cachedResult(): mixed.');
+        }
+
+        PermanentCacheUpdating::dispatch($this);
+
+        $value = $this->cachedResult();
+
+        [$store, $key] = $this->resolvePermanentCacheStore();
+
+        Cache::store($store)->forever($key, (object) [
+            'value' => $value,
+            'updated_at' => now(),
+        ]);
+
+        PermanentCacheUpdated::dispatch($this, $value);
+
+        return $value;
+    }
+
+    public function forgetCache(): bool
+    {
+        [$store, $key] = $this->resolvePermanentCacheStore();
+
+        return Cache::store($store)->forget($key);
+    }
+
+    public function isCached(): bool
+    {
+        [$store, $key] = $this->resolvePermanentCacheStore();
+
+        return Cache::store($store)->has($key);
+    }
+
+    public function cacheUpdatedAt(): ?Carbon
+    {
+        return $this->getPermanentCacheEntry()?->updated_at;
+    }
+
+    public function getPermanentCacheKey(): string
+    {
+        return $this->resolvePermanentCacheStore()[1];
+    }
+
+    public function getPermanentCacheStoreName(): string
+    {
+        return $this->resolvePermanentCacheStore()[0];
+    }
+
+    /**
+     * Query builder used to iterate records during warm/update. Override the
+     * `permanentCacheable` scope on the model to restrict the set.
+     *
+     * @return Builder<static>
+     */
+    public static function permanentCacheableQuery(): Builder
+    {
+        $query = static::query();
+
+        if (method_exists(static::class, 'scopePermanentCacheable')) {
+            $query->permanentCacheable();
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    protected function resolvePermanentCacheStore(): array
+    {
+        $primaryKey = $this->getKey();
+
+        if ($primaryKey === null || $primaryKey === '') {
+            throw new \LogicException(
+                static::class.' has no primary key value; per-record cache cannot be resolved. '
+                .'Save the record before caching it.'
+            );
+        }
+
+        $raw = property_exists($this, 'permanentCacheStore') ? $this->permanentCacheStore : null;
+
+        $store = (is_string($raw) && $raw !== '')
+            ? $raw
+            : (config('permanent-cache.store') ?: config('cache.default'));
+
+        $slug = preg_replace('/[^A-Za-z0-9]+/', '_', strtolower(Str::snake(class_basename(static::class))));
+
+        $key = $slug.':'.$primaryKey;
+
+        return [$store, $key];
+    }
+
+    protected function getPermanentCacheEntry(): ?object
+    {
+        [$store, $key] = $this->resolvePermanentCacheStore();
+
+        $entry = Cache::store($store)->get($key);
+
+        return is_object($entry) ? $entry : null;
+    }
+
+    protected function shouldQueuePermanentCache(): bool
+    {
+        return property_exists($this, 'permanentCacheQueue')
+            && $this->permanentCacheQueue === true;
+    }
+
+    public function getPermanentCacheExpression(): ?string
+    {
+        return property_exists($this, 'permanentCacheExpression') ? $this->permanentCacheExpression : null;
+    }
+}

--- a/src/Events/PermanentCacheUpdated.php
+++ b/src/Events/PermanentCacheUpdated.php
@@ -4,13 +4,14 @@ namespace Backstage\PermanentCache\Laravel\Events;
 
 use Backstage\PermanentCache\Laravel\Cached;
 use Backstage\PermanentCache\Laravel\CachedComponent;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class PermanentCacheUpdated
 {
     use Dispatchable;
 
-    public function __construct(public readonly Cached | CachedComponent $cache, public mixed $value)
+    public function __construct(public readonly Cached|CachedComponent|Model $cache, public mixed $value)
     {
         //
     }

--- a/src/Events/PermanentCacheUpdating.php
+++ b/src/Events/PermanentCacheUpdating.php
@@ -4,13 +4,14 @@ namespace Backstage\PermanentCache\Laravel\Events;
 
 use Backstage\PermanentCache\Laravel\Cached;
 use Backstage\PermanentCache\Laravel\CachedComponent;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class PermanentCacheUpdating
 {
     use Dispatchable;
 
-    public function __construct(public readonly Cached | CachedComponent $cache)
+    public function __construct(public readonly Cached|CachedComponent|Model $cache)
     {
         //
     }

--- a/src/Jobs/RefreshModelCacheJob.php
+++ b/src/Jobs/RefreshModelCacheJob.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Backstage\PermanentCache\Laravel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RefreshModelCacheJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {
+        //
+    }
+
+    public function handle(): void
+    {
+        if (! method_exists($this->model, 'writePermanentCache')) {
+            return;
+        }
+
+        $this->model->writePermanentCache();
+    }
+}

--- a/src/PermanentCache.php
+++ b/src/PermanentCache.php
@@ -2,6 +2,9 @@
 
 namespace Backstage\PermanentCache\Laravel;
 
+use Backstage\PermanentCache\Laravel\Concerns\HasPermanentCache;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
@@ -9,6 +12,9 @@ use SplObjectStorage;
 
 class PermanentCache
 {
+    /** @var array<int, class-string<Model>> */
+    protected array $models = [];
+
     public function __construct(
         protected SplObjectStorage $caches,
         protected Application $app,
@@ -58,17 +64,92 @@ class PermanentCache
     }
 
     /**
-     * Update all registered permanent caches
+     * Register Eloquent models for per-record permanent caching.
+     *
+     * Each registered model class must use the HasPermanentCache trait. Eloquent
+     * saved/deleted (and restored, when SoftDeletes is used) listeners are attached
+     * automatically so cache entries stay in sync with the underlying record.
+     *
+     * @param  class-string<Model>|array<int, class-string<Model>>  ...$models
+     */
+    public function models(...$models): self
+    {
+        $classes = collect($models)
+            ->flatMap(fn ($entry) => is_array($entry) ? $entry : [$entry])
+            ->filter()
+            ->values()
+            ->all();
+
+        foreach ($classes as $class) {
+            $this->registerModel($class);
+        }
+
+        return $this;
+    }
+
+    /** @return array<int, class-string<Model>> */
+    public function registeredModels(): array
+    {
+        return $this->models;
+    }
+
+    public function configuredCaches(): SplObjectStorage
+    {
+        return $this->caches;
+    }
+
+    /**
+     * Update all registered permanent caches AND warm all registered model caches.
      */
     public function update(): void
     {
         foreach ($this->caches as $cache) {
             $cache->update();
         }
+
+        foreach ($this->models as $model) {
+            $this->warmModel($model);
+        }
     }
 
-    public function configuredCaches(): SplObjectStorage
+    /**
+     * @param  class-string<Model>  $class
+     */
+    protected function registerModel(string $class): void
     {
-        return $this->caches;
+        if (! is_subclass_of($class, Model::class)) {
+            throw new \InvalidArgumentException("[{$class}] is not an Eloquent model.");
+        }
+
+        if (! in_array(HasPermanentCache::class, class_uses_recursive($class), true)) {
+            throw new \InvalidArgumentException(
+                "[{$class}] must use the ".HasPermanentCache::class.' trait to be registered.'
+            );
+        }
+
+        if (in_array($class, $this->models, true)) {
+            return;
+        }
+
+        $this->models[] = $class;
+
+        $class::saved(static fn (Model $model) => $model->refreshCache());
+        $class::deleted(static fn (Model $model) => $model->forgetCache());
+
+        if (in_array(SoftDeletes::class, class_uses_recursive($class), true)) {
+            $class::restored(static fn (Model $model) => $model->refreshCache());
+        }
+    }
+
+    /**
+     * @param  class-string<Model>  $class
+     */
+    protected function warmModel(string $class): void
+    {
+        $class::permanentCacheableQuery()->chunkById(1000, function ($records) {
+            foreach ($records as $record) {
+                $record->refreshCache();
+            }
+        });
     }
 }

--- a/src/PermanentCacheServiceProvider.php
+++ b/src/PermanentCacheServiceProvider.php
@@ -4,6 +4,7 @@ namespace Backstage\PermanentCache\Laravel;
 
 use Backstage\PermanentCache\Laravel\Commands\PermanentCacheStatusCommand;
 use Backstage\PermanentCache\Laravel\Commands\UpdatePermanentCacheCommand;
+use Backstage\PermanentCache\Laravel\Commands\WarmPermanentCacheCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -15,7 +16,8 @@ class PermanentCacheServiceProvider extends PackageServiceProvider
         $package->name('laravel-permanent-cache')
             ->hasCommands(
                 PermanentCacheStatusCommand::class,
-                UpdatePermanentCacheCommand::class
+                UpdatePermanentCacheCommand::class,
+                WarmPermanentCacheCommand::class,
             )
             ->hasConfigFile();
     }
@@ -27,11 +29,22 @@ class PermanentCacheServiceProvider extends PackageServiceProvider
 
     public function bootingPackage()
     {
-        $this->callAfterResolving(
-            Schedule::class,
-            fn (Schedule $schedule) => collect(Facades\PermanentCache::configuredCaches())
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {
+            collect(Facades\PermanentCache::configuredCaches())
                 ->filter(fn ($cacher) => is_a($cacher, Scheduled::class))
-                ->each(fn ($cacher) => $cacher->schedule($schedule->job($cacher)))
-        );
+                ->each(fn ($cacher) => $cacher->schedule($schedule->job($cacher)));
+
+            foreach (Facades\PermanentCache::registeredModels() as $modelClass) {
+                $expression = (new $modelClass)->getPermanentCacheExpression();
+
+                if ($expression === null) {
+                    continue;
+                }
+
+                $schedule->command(WarmPermanentCacheCommand::class, [
+                    '--filter='.class_basename($modelClass),
+                ])->cron($expression);
+            }
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,4 +13,14 @@ class TestCase extends Orchestra
             PermanentCacheServiceProvider::class,
         ];
     }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
 }

--- a/tests/Unit/HasPermanentCache/HasPermanentCacheTest.php
+++ b/tests/Unit/HasPermanentCache/HasPermanentCacheTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Backstage\PermanentCache\Laravel\Facades\PermanentCache;
+use Backstage\PermanentCache\Laravel\Tests\Unit\HasPermanentCache\TestModel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    Cache::store('file')->clear();
+
+    Schema::dropIfExists('test_models');
+    Schema::create('test_models', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+    });
+
+    (fn () => $this->models = [])->call(app(Backstage\PermanentCache\Laravel\PermanentCache::class));
+});
+
+it('throws when caching a record without a primary key', function () {
+    (new TestModel(['name' => 'unsaved']))->cached();
+})->throws(LogicException::class, 'has no primary key value');
+
+it('computes and stores the cached result on first access', function () {
+    $model = TestModel::create(['name' => 'first']);
+
+    PermanentCache::models([TestModel::class]);
+
+    Cache::store('file')->forget("test_model:{$model->getKey()}");
+
+    expect($model->isCached())->toBeFalse();
+
+    $value = $model->cached();
+
+    expect($model->isCached())->toBeTrue();
+    expect($value['name'])->toBe('first');
+    expect($model->cacheUpdatedAt())->not->toBeNull();
+});
+
+it('builds the cache key from the model basename and primary key', function () {
+    $model = TestModel::create(['name' => 'keyed']);
+    $model->writePermanentCache();
+
+    expect(Cache::store('file')->has("test_model:{$model->getKey()}"))->toBeTrue();
+});
+
+it('refreshes the cache when a registered model is saved', function () {
+    PermanentCache::models([TestModel::class]);
+
+    $model = TestModel::create(['name' => 'saved']);
+
+    expect($model->isCached())->toBeTrue();
+
+    $first = $model->cached();
+    usleep(1000);
+    $model->update(['name' => 'updated']);
+
+    $second = $model->fresh()->cached();
+
+    expect($second['name'])->toBe('updated');
+    expect($second['computed_at'])->toBeGreaterThan($first['computed_at']);
+});
+
+it('forgets the cache when a registered model is deleted', function () {
+    PermanentCache::models([TestModel::class]);
+
+    $model = TestModel::create(['name' => 'doomed']);
+    expect($model->isCached())->toBeTrue();
+
+    $key = "test_model:{$model->getKey()}";
+    $model->delete();
+
+    expect(Cache::store('file')->has($key))->toBeFalse();
+});
+
+it('rejects registering a class without the trait', function () {
+    PermanentCache::models([Model::class]);
+})->throws(InvalidArgumentException::class);
+
+it('warms all registered records via the warm command', function () {
+    PermanentCache::models([TestModel::class]);
+
+    Cache::store('file')->clear();
+
+    TestModel::create(['name' => 'a']);
+    TestModel::create(['name' => 'b']);
+    TestModel::create(['name' => 'c']);
+
+    Cache::store('file')->clear();
+
+    $this->artisan('permanent-cache:warm', ['--sync' => true])->assertSuccessful();
+
+    expect(Cache::store('file')->has('test_model:1'))->toBeTrue();
+    expect(Cache::store('file')->has('test_model:2'))->toBeTrue();
+    expect(Cache::store('file')->has('test_model:3'))->toBeTrue();
+});

--- a/tests/Unit/HasPermanentCache/TestModel.php
+++ b/tests/Unit/HasPermanentCache/TestModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backstage\PermanentCache\Laravel\Tests\Unit\HasPermanentCache;
+
+use Backstage\PermanentCache\Laravel\Concerns\HasPermanentCache;
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    use HasPermanentCache;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $permanentCacheStore = 'file';
+
+    public function cachedResult(): mixed
+    {
+        return [
+            'id' => $this->getKey(),
+            'name' => $this->name,
+            'computed_at' => microtime(true),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-record permanent caching for Eloquent models alongside the existing class-level `Cached` flow.

- `HasPermanentCache` trait: `cached()`, `refreshCache()`, `forgetCache()`, `isCached()`, `cacheUpdatedAt()`.
- `$permanentCacheStore` selects the **cache connection** only; the cache key is always `<model_basename>:<getKey()>`. Records without a primary key throw a `LogicException`.
- Optional per-model knobs: `$permanentCacheExpression` (cron), `$permanentCacheQueue` (+ connection/name).
- Registration in \`AppServiceProvider::boot()\`:
  \`\`\`php
  PermanentCache::models([User::class, Order::class]);
  \`\`\`
  Auto-attaches \`saved\` → refresh, \`deleted\` → forget, \`restored\` → refresh.
- \`RefreshModelCacheJob\` for queued refreshes.
- \`php artisan permanent-cache:warm\` iterates registered models in chunks; supports \`--filter\`, \`--queue\`, \`--sync\`, \`--chunk\`.
- \`permanent-cache:update\` warms registered models after class caches.
- Service provider schedules \`permanent-cache:warm --filter=<basename>\` per model that defines a cron expression.
- \`PermanentCacheUpdating\`/\`Updated\` events now also accept Eloquent \`Model\`.

## Test plan
- [x] \`vendor/bin/pest\` — all 18 tests pass (7 new).
- [ ] Smoke-test in a host app: register a model, save → cache populated, update → entry refreshed, delete → entry forgotten.
- [ ] \`php artisan permanent-cache:warm\` with multiple registered models.
- [ ] \`php artisan permanent-cache:update\` rebuilds class caches **and** model caches.